### PR TITLE
fix: make message visible for tip and post till tnx complets

### DIFF
--- a/frontend/src/components/Feed.jsx
+++ b/frontend/src/components/Feed.jsx
@@ -78,7 +78,8 @@ const Feed = () => {
     setOpenCreate(false)
     message.loading({
       content: 'Processing Transaction...',
-      key: loadingMessageKey
+      key: loadingMessageKey,
+      duration: 0 
     })
     try {
       await Message(values.Message, values.URL)
@@ -105,7 +106,8 @@ const Feed = () => {
     setOpenTip(false)
     message.loading({
       content: 'Processing Transaction...',
-      key: loadingMessageKey
+      key: loadingMessageKey,
+      duration: 0 
     })
     try {
       // Convert the Amount to a string


### PR DESCRIPTION
Same small issue in `/feed` for tipping and making a post to the feed @kpachhai 

Setting the duration to 0 keeps it until it updates, if not set, the duration will default to 3 seconds from the lib, so no updates for the user if tnx takes longer than 3s. 